### PR TITLE
Revert XIPP-20267: regressão de performance no core de tradução (derruba preprod)

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1732,29 +1732,21 @@ def load_language(cr, lang):
     installer.lang_install()
 
 
-def get_po_paths(module_name: str, lang: str, env: odoo.api.Environment | None = None, include_overrides: bool = False):
+def get_po_paths(module_name: str, lang: str, env: odoo.api.Environment | None = None):
     lang_base = lang.split('_', 1)[0]
     # Load the base as a fallback in case a translation is missing:
     po_names = [lang_base, lang]
     # Exception for Spanish locales: they have two bases, es and es_419:
     if lang_base == 'es' and lang not in ('es_ES', 'es_419'):
         po_names.insert(1, 'es_419')
-
-    def module_paths(module):
-        for filename in OrderedSet(po_names):
-            for dir_ in ('i18n', 'i18n_extra'):
-                with suppress(FileNotFoundError):
-                    yield file_path(join(module, dir_, filename + '.po'), env=env)
-
-    yield from module_paths(module_name)
-
-    if not include_overrides:
-        return
-
-    for addon in odoo.modules.get_modules():
-        if addon == module_name:
-            continue
-        yield from module_paths(addon)
+    po_paths = (
+        join(module_name, dir_, filename + '.po')
+        for filename in OrderedSet(po_names)
+        for dir_ in ('i18n', 'i18n_extra')
+    )
+    for path in po_paths:
+        with suppress(FileNotFoundError):
+            yield file_path(path, env=env)
 
 
 class CodeTranslations:
@@ -1782,7 +1774,7 @@ class CodeTranslations:
 
     @staticmethod
     def _get_code_translations(module_name, lang, filter_func):
-        po_paths = get_po_paths(module_name, lang, include_overrides=True)
+        po_paths = get_po_paths(module_name, lang)
         translations = {}
         for po_path in po_paths:
             try:


### PR DESCRIPTION
## Motivo
O commit `1a82346e` (fix XIPP-20267, Augusto) alterou `_get_code_translations` para chamar `get_po_paths(..., include_overrides=True)`, que passou a **varrer TODOS os ~389 módulos** (`for addon in odoo.modules.get_modules()`) tentando abrir `i18n/<lang>.po` + `i18n_extra` de cada um, **por módulo** → O(módulos²) ≈ 150k+ operações de filesystem por carga de tradução, por worker.

## Impacto (preprod18, 03/07)
Workers presos a ~100% CPU em `futex_wait` (contenção no cache CodeTranslations / GIL), sem query no DB → web timeout (000). Não era recompute/cron/xmlrpc — esses só disparavam o path de tradução caro. Arquivo core read-only no pod → não deu pra hotpatch → revert + rebuild.

## Ação
Revert do commit. Restaura o `get_po_paths`/`_get_code_translations` originais. XIPP-20267 (carregar overrides de tradução de outros módulos) precisa ser re-implementado sem varrer todos os módulos (ex.: lista explícita de módulos-override, ou cache global).