### PR TITLE
[I18N] base pt_BR: mensagem de regra de registro (XIPP-20267) — só PO nativo

### DIFF
--- a/odoo/addons/base/i18n/pt_BR.po
+++ b/odoo/addons/base/i18n/pt_BR.po
@@ -30443,8 +30443,8 @@ msgid ""
 "If you really, really need access, perhaps you can win over your friendly "
 "administrator with a batch of freshly baked cookies."
 msgstr ""
-"Se você realmente precisar de acesso, talvez valha a pena tentar conquistar "
-"o administrador com uns pães de queijo."
+"Acesso restrito. Entre em contato com o administrador do sistema para "
+"solicitar autorização."
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_model_access__active
@@ -47817,7 +47817,7 @@ msgid ""
 "\n"
 "Sorry, %(user)s doesn't have '%(operation)s' access to:"
 msgstr ""
-"Ops! Parece que você se deparou com alguns registros ultrassecretos.\n"
+"Parece que você se deparou com alguns registros restritos.\n"
 "\n"
 "Desculpe, %(user)s não tem '%(operation)s' acesso a:"
 


### PR DESCRIPTION
Faz o que o XIPP-20267 queria, do jeito certo: traduz as 2 mensagens de acesso negado por regra de registro (base/models/ir_rule.py) direto no PO nativo do base — SEM código, SEM override-scan. Substitui o approach do commit revertido (PR #5) que varria todos os módulos (O(módulos²), derrubou o preprod). Só `odoo/addons/base/i18n/pt_BR.po`.